### PR TITLE
Fix Node Selection Bug

### DIFF
--- a/dgidb/graph_app.py
+++ b/dgidb/graph_app.py
@@ -108,6 +108,8 @@ def update_selected_node(app):
             return ""
         if clickData is not None and 'points' in clickData:
             selected_node = clickData['points'][0]
+            if 'text' not in selected_node:
+                return dash.no_update
             return selected_node
         return dash.no_update
 


### PR DESCRIPTION
-Identified an issue where a 'false node', lacking vital node information (such as the node's name ['text']), can be selected.

-Added a conditional check to ensure that selected nodes are not 'false nodes', to prevent future errors with operations involving them.